### PR TITLE
':' causes error in JSON

### DIFF
--- a/renderer/renderer.uc
+++ b/renderer/renderer.uc
@@ -310,6 +310,10 @@ let services = {
 		this.state[name] = state ? true : false;
 	},
 
+	is_present: function(name) {
+		return length(fs.stat("/etc/init.d" + name)) > 0;
+	}
+
 	lookup_interfaces: function(service) {
 		let interfaces = [];
 

--- a/renderer/templates/interface/firewall.uc
+++ b/renderer/templates/interface/firewall.uc
@@ -8,7 +8,7 @@ set firewall.@zone[-1].forward='REJECT'
 set firewall.@zone[-1].masq=1
 set firewall.@zone[-1].mtu_fix=1
 {% else %}
-set firewall.@zone[-1].input='ACCEPT'
+set firewall.@zone[-1].input='REJECT'
 set firewall.@zone[-1].output='ACCEPT'
 set firewall.@zone[-1].forward='ACCEPT'
 

--- a/renderer/templates/services/http.uc
+++ b/renderer/templates/services/http.uc
@@ -1,3 +1,4 @@
+{% if (!services.is_present("uhttpd")) return %}
 {% let interfaces = services.lookup_interfaces("http") %}
 {% let enable = length(interfaces) %}
 {% services.set_enabled("uhttpd", enable) %}

--- a/renderer/templates/services/ieee8021x.uc
+++ b/renderer/templates/services/ieee8021x.uc
@@ -1,3 +1,4 @@
+{% if (!services.is_present("ieee8021x")) return %}
 {% let interfaces = services.lookup_interfaces("ieee8021x") %}
 {% let enable = length(interfaces) %}
 {% services.set_enabled("ieee8021x", enable) %}

--- a/renderer/templates/services/igmp.uc
+++ b/renderer/templates/services/igmp.uc
@@ -1,3 +1,4 @@
+{% if (!services.is_present("igmpproxy")) return %}
 {% let interfaces = services.lookup_interfaces("igmp") %}
 {% let enable = length(interfaces) %}
 {% services.set_enabled("igmpproxy", enable) %}

--- a/renderer/templates/services/lldp.uc
+++ b/renderer/templates/services/lldp.uc
@@ -1,3 +1,4 @@
+{% if (!services.is_present("lldpd")) return %}
 {% let interfaces = services.lookup_interfaces("lldp") %}
 {% let enable = length(interfaces) %}
 {% services.set_enabled("lldpd", enable) %}

--- a/renderer/templates/services/mdns.uc
+++ b/renderer/templates/services/mdns.uc
@@ -1,3 +1,4 @@
+{% if (!services.is_present("umdns")) return %}
 {% let interfaces = services.lookup_interfaces("mdns") %}
 {% let enable = length(interfaces) %}
 {% services.set_enabled("umdns", enable) %}

--- a/renderer/templates/services/radius_proxy.uc
+++ b/renderer/templates/services/radius_proxy.uc
@@ -1,3 +1,4 @@
+{% if (!services.is_present("radsecproxy")) return %}
 {% let enable = length(radius_proxy) %}
 {% services.set_enabled("radsecproxy", enable) %}
 {% if (!enable) return %}

--- a/renderer/templates/services/rtty.uc
+++ b/renderer/templates/services/rtty.uc
@@ -1,3 +1,4 @@
+{% if (!services.is_present("rtty")) return %}
 {% let enable = length(rtty) %}
 {% services.set_enabled("rtty", enable) %}
 {% if (!enable) return %}

--- a/renderer/templates/services/wifi_steering.uc
+++ b/renderer/templates/services/wifi_steering.uc
@@ -1,3 +1,4 @@
+{% if (!services.is_present("usteer")) return %}
 {% let ssids = services.lookup_ssids("wifi-steering") %}
 {% let enable = (wifi_steering.mode == 'local' && length(ssids)) %}
 {% services.set_enabled("usteer", enable) %}

--- a/schema/radio.yml
+++ b/schema/radio.yml
@@ -11,7 +11,7 @@ properties:
     - 6G
   bandwidth:
     description:
-      Specifies a narrow channel width in MHz, possible values are: 5, 10, 20.
+      Specifies a narrow channel width in MHz, possible values are 5, 10, 20.
     type: integer
     enum:
     - 5

--- a/schema/ucentral.yml
+++ b/schema/ucentral.yml
@@ -5,7 +5,7 @@ type: object
 properties:
   uuid:
     description:
-      The uniquie ID of the configuration. This is the unix timestamp of when the config was created.
+      The unique ID of the configuration. This is the unix timestamp of when the config was created.
     type: integer
   unit:
     $ref: "https://ucentral.io/schema/v1/unit/"


### PR DESCRIPTION
Because the ':' in the description string, when the schema is automatically converted to JSON, "description" is converted to an object instead of a string. Removing the ':' will ensure that the description will be converted to a string instead of this:

```
"description": {
                            "Specifies a narrow channel width in MHz, possible values are": "5, 10, 20."
                        },
```