### PR TITLE
Files handling

### DIFF
--- a/generate-example.uc
+++ b/generate-example.uc
@@ -203,6 +203,9 @@ function random_value(kind, minLength, maxLength) {
 
 		break;
 
+	case 'uc-base64':
+		return b64enc(random_phrase(50, 100));
+
 	default:
 		if (minLength <= 15 && maxLength >= 20)
 			return random_phrase(minLength, maxLength);

--- a/generate-reader.uc
+++ b/generate-reader.uc
@@ -91,6 +91,12 @@ let GeneratorProto = {
 				'return match(value, /^[0-9]+[smhdw]$/);'
 			]
 		},
+		"uc-base64": {
+			desc: 'base64 encoded data',
+			code: [
+				'return b64dec(value) != null;'
+			]
+		},
 		"hostname": {
 			desc: 'hostname',
 			code: [

--- a/renderer/renderer.uc
+++ b/renderer/renderer.uc
@@ -478,6 +478,110 @@ let dhcp_relay = {
 	}
 };
 
+let files = {
+	files: {},
+	basedir: '/tmp/ucentral',
+
+	escape: function(s) {
+		return replace(s, /[~\/]/g, m => (m == '~' ? '~0' : '~1'));
+	},
+
+	add_named: function(path, content) {
+		if (index(path, '/') != 0)
+			path = this.basedir + '/' + path;
+
+		this.files[path] = content;
+	},
+
+	add_anonymous: function(location, name, content) {
+		let path = this.basedir + '/' + this.escape(location) + '/' + this.escape(name);
+
+		this.files[path] = content;
+
+		return path;
+	},
+
+	purge: function(logs, dir) {
+		if (dir == null)
+			dir = this.basedir;
+
+		let d = fs.opendir(this.basedir);
+
+		if (d) {
+			let e;
+
+			while ((e = d.read()) != null) {
+				let p = dir + '/' + e,
+				    s = fs.lstat(p);
+
+				if (s == null)
+					push(logs, sprintf("[W] Unable to lstat() path '%s': %s", p, fs.error()));
+				else if (s.type == 'directory')
+					this.purge(logs, p);
+				else if (!fs.unlink(p))
+					push(logs, sprintf("[W] Unable to unlink() path '%s': %s", p, fs.error()));
+			}
+
+			d.close();
+
+			if (dir != this.basedir && !fs.rmdir(dir))
+				push(logs, sprintf("[W] Unable to rmdir() path '%s': %s", dir, fs.error()));
+		}
+		else {
+			push(logs, sprintf("[W] Unable to opendir() path '%s': %s", dir, fs.error()));
+		}
+	},
+
+	mkdir_path: function(logs, path) {
+		assert(index(path, '/') == 0, "Expecting absolute path");
+
+		let segments = split(path, '/'),
+		    tmppath = shift(segments);
+
+		for (let i = 0; i < length(segments) - 1; i++) {
+			tmppath += '/' + segments[i];
+
+			let s = fs.stat(tmppath);
+
+			if (s != null && s.type == 'directory')
+				continue;
+
+			if (fs.mkdir(tmppath))
+				continue;
+
+			push(logs, sprintf("[E] Unable to mkdir() path '%s': %s", tmppath, fs.error()));
+
+			return false;
+		}
+
+		return true;
+	},
+
+	write: function(logs) {
+		let success = true;
+
+		for (let path, content in this.files) {
+			if (!this.mkdir_path(logs, path)) {
+				success = false;
+				continue;
+			}
+
+			let f = fs.open(path, "w");
+
+			if (f) {
+				f.write(content);
+				f.close();
+			}
+			else {
+				push(logs, sprintf("[E] Unable to open() path '%s' for writing: %s", path, fs.error()));
+				success = false;
+			}
+		}
+
+		return success;
+	}
+};
+
 return {
 	render: function(state, logs) {
 		logs = logs || [];
@@ -493,13 +597,25 @@ return {
 			services,
 			dhcp_relay,
 			location: '/',
-			fs,
 			cursor,
 			capab,
+			files,
 
 			warn: (fmt, ...args) => push(logs, sprintf("[W] (In %s) ", location || '/') + sprintf(fmt, ...args)),
 			info: (fmt, ...args) => push(logs, sprintf("[!] (In %s) ", location || '/') + sprintf(fmt, ...args))
 		});
+	},
+
+	write_files: function(logs) {
+		logs = logs || [];
+
+		files.purge(logs);
+
+		return files.write(logs);
+	},
+
+	files_state: function() {
+		return files.files;
 	},
 
 	services_state: function() {

--- a/renderer/templates/eap_users.uc
+++ b/renderer/templates/eap_users.uc
@@ -1,0 +1,4 @@
+{% for (let user in users): %}
+"{{ user.user_name }}"	PWD	"{{ user.password }}"
+{% endfor %}
+* TLS,TTLS

--- a/renderer/templates/interface/ssid.uc
+++ b/renderer/templates/interface/ssid.uc
@@ -200,13 +200,8 @@ set wireless.{{ section }}.private_key={{ s(certificates.private_key) }}
 set wireless.{{ section }}.private_key_passwd={{ s(certificates.private_key_password) }}
 set wireless.{{ section }}.server_id={{ s(crypto.eap_local.server_identity) }}
 set wireless.{{ section }}.eap_user_file={{ s(crypto.eap_user) }}
-{%   let user_file = fs.open(crypto.eap_user, "w");
-     for (let user in crypto.eap_local.users)
-	user_file.write('"' + user.user_name + '"\tPWD\t"' + user.password + '"\n');
-     if (certificates.ca_certificate && certificates.certificate && certificates.private_key)
-	user_file.write('* TLS,TTLS\n');
-	user_file.close();
-     endif %}
+{%     files.add_named(crypto.eap_user, render("../eap_users.uc", { users: crypto.eap_local.users })) %}
+{%   endif %}
 
 {%   if (crypto.auth): %}
 set wireless.{{ section }}.auth_server={{ crypto.auth.host }}

--- a/renderer/templates/services/ieee8021x.uc
+++ b/renderer/templates/services/ieee8021x.uc
@@ -33,8 +33,4 @@ set network.@device[-1].name={{ s(port) }}
 set network.@device[-1].auth='1'
 {%  endfor %}
 {% endfor %}
-{% let user_file = fs.open("/var/run/hostapd-ieee8021x.eap_user", "w");
-   for (let user in ieee8021x.users)
-     user_file.write('"' + user.user_name + '"\tPWD\t"' + user.password + '"\n');
-   user_file.write('* TLS,TTLS\n');
-   user_file.close();%}
+{% files.add_named("/var/run/hostapd-ieee8021x.eap_user", render("../eap_users.uc", { users: ieee8021x.users })) %}

--- a/renderer/templates/services/ssh.uc
+++ b/renderer/templates/services/ssh.uc
@@ -2,15 +2,13 @@
 {% let enable = length(interfaces) %}
 {% services.set_enabled("dropbear", enable) %}
 {% if (!enable) return %}
+{% files.add_named("/etc/dropbear/authorized_keys", join("\n", ssh.authorized_keys || []) + "\n") %}
 
 # SSH service configuration
 
-set dropbear.@dropbear[-1].enable={{ b(length(filter(state.interfaces, interface => ("ssh" in interface.services)))) }}
+set dropbear.@dropbear[-1].enable={{ b(enable) }}
 set dropbear.@dropbear[-1].Port={{ s(ssh.port) }}
 set dropbear.@dropbear[-1].PasswordAuth={{ b(ssh.password_authentication) }}
-{% for (let key in ssh.authorized_keys): %}
-add_list dropbear.@dropbear[-1].pubkey={{ s(key) }}
-{% endfor %}
 
 {% for (let interface in interfaces): %}
 {%    let name = ethernet.calculate_name(interface) %}

--- a/renderer/ucentral.uc
+++ b/renderer/ucentral.uc
@@ -51,6 +51,8 @@ try {
 		apply.write(batch);
 		apply.close();
 
+		renderer.write_files(logs);
+
 		set_service_state(false);
 
 		for (let cmd in [ 'uci -c /tmp/config-shadow commit',

--- a/schemareader.uc
+++ b/schemareader.uc
@@ -34,6 +34,10 @@ function matchUcTimeout(value) {
 	return match(value, /^[0-9]+[smhdw]$/);
 }
 
+function matchUcBase64(value) {
+	return b64dec(value) != null;
+}
+
 function matchHostname(value) {
 	if (length(value) > 255) return false;
 	let labels = split(value, ".");

--- a/selftest.sh
+++ b/selftest.sh
@@ -28,10 +28,16 @@ ucode -s '{%
 
 		let state = schemareader.validate(inputjson, logs);
 		let batch = state ? renderer.render(state, logs) : "";
+		let files = state ? renderer.files_state() : {};
 
 		fs.stdout.write("Log messages:\n" + join("\n", logs) + "\n\n");
 
 		fs.stdout.write("UCI batch output:\n" + batch + "\n");
+
+		fs.stdout.write("Files:\n\n");
+
+		for (let path in sort(keys(files)))
+			fs.stdout.write(" * " + path + "\n   --\n   " + replace(files[path], "\n", "\n   ") + "\n   --\n\n");
 	}
 	catch (e) {
 		warn("Fatal error while generating UCI: ", e, "\n", e.stacktrace[0].context, "\n");


### PR DESCRIPTION
     - Introduce a "files" helper and pass it to the render template context
     - Convert the EAP user file printing into a template operation
     - Display staged files in selftest.sh
     - Write staged files in ucentral.uc
     - Introduce uc-base64 format
