### PR TITLE
openflow: add port property

### DIFF
--- a/renderer/templates/services/open_flow.uc
+++ b/renderer/templates/services/open_flow.uc
@@ -23,7 +23,7 @@ set openvswitch.ovs.key={{ s(files.add_anonymous(location, 'key', b64dec(open_fl
 
 delete openvswitch.@ovs_bridge[0]
 add openvswitch ovs_bridge
-set openvswitch.@ovs_bridge[-1].controller="{{ open_flow.mode }}:{{ open_flow.controller }}"
+set openvswitch.@ovs_bridge[-1].controller="{{ open_flow.mode }}:{{ open_flow.controller }}:{{ open_flow.port }}"
 {% if (length(open_flow.datapath_description)): %}
 	set openvswitch.@ovs_bridge[-1].datapath_desc="{{ s(open_flow.datapath_description) }}"
 {% endif %}

--- a/schema/service.open-flow.yml
+++ b/schema/service.open-flow.yml
@@ -23,6 +23,12 @@ properties:
       - ssl
       - tcp
     default: ssl
+  port:
+    description:
+      The port to use for the OpenFlow controller target.
+    type: integer
+    maximum: 65535
+    default: 6653
   ca-certificate:
     description:
        The CA certificate.

--- a/schemareader.uc
+++ b/schemareader.uc
@@ -5051,6 +5051,26 @@ function instantiateServiceOpenFlow(location, value, errors) {
 			obj.mode = "ssl";
 		}
 
+		function parsePort(location, value, errors) {
+			if (type(value) in [ "int", "double" ]) {
+				if (value > 65535)
+					push(errors, [ location, "must be lower than or equal to 65535" ]);
+
+			}
+
+			if (type(value) != "int")
+				push(errors, [ location, "must be of type integer" ]);
+
+			return value;
+		}
+
+		if (exists(value, "port")) {
+			obj.port = parsePort(location + "/port", value["port"], errors);
+		}
+		else {
+			obj.port = 6653;
+		}
+
 		function parseCaCertificate(location, value, errors) {
 			if (type(value) != "string")
 				push(errors, [ location, "must be of type string" ]);

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -1937,6 +1937,11 @@
                     ],
                     "default": "ssl"
                 },
+                "port": {
+                    "type": "integer",
+                    "maximum": 65535,
+                    "default": 6653
+                },
                 "ca-certificate": {
                     "type": "string"
                 },


### PR DESCRIPTION
Commit 727159535e65 ("schema: extend QoS schema") completely broke
OpenFlow by requiring a CIDR for the OpenFlow controller field.
Commit e440ced24db6 ("open-flow: fix controller property type") fixed
that, but as a result, it's no longer possible to specify a port.

Solve this cleanly by adding another property for the OpenFlow port.

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>