### PR TITLE
renderer: fix OpenFlow bridge mode

### DIFF
--- a/renderer/templates/interface.uc
+++ b/renderer/templates/interface.uc
@@ -177,7 +177,7 @@
 		include('interface/captive.uc', { name });
 %}
 
-{% if ("open-flow" in interface.services): %}
+{% if (interface.role == "downstream" && "open-flow" in interface.services): %}
 {% for (let port in keys(eth_ports)): %}
 add openvswitch ovs_port;
 set openvswitch.@ovs_port[-1].bridge="br-ovs";

--- a/renderer/templates/services/open_flow.uc
+++ b/renderer/templates/services/open_flow.uc
@@ -28,6 +28,7 @@ set openvswitch.@ovs_bridge[-1].controller="{{ open_flow.mode }}:{{ open_flow.co
 	set openvswitch.@ovs_bridge[-1].datapath_desc="{{ s(open_flow.datapath_description) }}"
 {% endif %}
 set openvswitch.@ovs_bridge[-1].datapath_id="0x{{ serial }}"
+set openvswitch.@ovs_bridge[-1].drop_unknown_ports="1"
 set openvswitch.@ovs_bridge[-1].name="br-ovs"
 
 add openvswitch ovs_port

--- a/schema/service.open-flow.yml
+++ b/schema/service.open-flow.yml
@@ -4,7 +4,7 @@ type: object
 properties:
   controller:
     description:
-      The CIDR of the OpenFlow controller target.
+      The IP address of the OpenFlow controller target.
     type: string
     format: uc-ip
     example: 192.168.10.1


### PR DESCRIPTION
Fix OpenFlow in bridge mode. This got broken by adding wired ports to the bridge unconditionally. While testing I ran into vague issues where netifd refused to add the WAN port in the up bridge, due to Open vSwitch still having it in its database. This problem persisted even after removing it manually. However, enabling drop_unknown_ports seemed to fix all that, and I have been able to successfully switch between bridged and routed mode several times without rebooting.

The third patch just corrects a description, to avoid confusion.