### PR TITLE
Introduce firewall settings

### DIFF
--- a/generate-example.uc
+++ b/generate-example.uc
@@ -211,6 +211,14 @@ function random_value(kind, minLength, maxLength) {
 	case 'uc-base64':
 		return b64enc(random_phrase(50, 100));
 
+	case 'uc-portrange':
+		switch (math.rand() % 2) {
+		case 0: return sprintf('%d', math.rand() % 65536);
+		case 1: return join('-', sort([ math.rand() % 65536, math.rand() % 65536 ]));
+		}
+
+		break;
+
 	default:
 		if (minLength <= 15 && maxLength >= 20)
 			return random_phrase(minLength, maxLength);

--- a/generate-example.uc
+++ b/generate-example.uc
@@ -1,8 +1,4 @@
-#!/usr/bin/env ucode
-{%
-
-push(REQUIRE_SEARCH_PATH,
-	"/usr/local/lib/ucode/*.so");
+#!/usr/bin/env -S ucode -R
 
 let fs = require("fs");
 let math = require("math");

--- a/generate-example.uc
+++ b/generate-example.uc
@@ -152,6 +152,7 @@ function random_value(kind, minLength, maxLength) {
 
 	case 'hostname':
 	case 'idn-hostname':
+	case 'uc-fqdn':
 		return random_hostname();
 
 	case 'uri':

--- a/generate-reader.uc
+++ b/generate-reader.uc
@@ -1,6 +1,4 @@
-#!/usr/bin/env ucode
-{%
-
+#!/usr/bin/env -S ucode -R
 "use strict";
 
 let fs = require("fs");
@@ -564,7 +562,6 @@ let GeneratorProto = {
 
 		this.schema = this.read_schema(this.path);
 
-		this.print(indent, '{%');
 		this.print(indent, '// Automatically generated from %s - do not edit!', this.path);
 		this.print(indent, '"use strict";\n');
 

--- a/generate-reader.uc
+++ b/generate-reader.uc
@@ -105,7 +105,7 @@ let GeneratorProto = {
 				'return (length(filter(labels, label => !match(label, /^([a-zA-Z0-9]{1,2}|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9])$/))) == 0 && length(labels) > 0);'
 			]
 		},
-		"fqdn": {
+		"uc-fqdn": {
 			desc: 'fully qualified domain name',
 			code: [
 				'if (length(value) > 255) return false;',

--- a/generate-reader.uc
+++ b/generate-reader.uc
@@ -95,6 +95,15 @@ let GeneratorProto = {
 				'return b64dec(value) != null;'
 			]
 		},
+		"uc-portrange": {
+			desc: 'network port range',
+			code: [
+				'let ports = match(value, /^([0-9]|[1-9][0-9]*)(-([0-9]|[1-9][0-9]*))?$/);',
+				'if (!ports) return false;',
+				'let min = +ports[1], max = ports[2] ? +ports[3] : min;',
+				'return (min <= 65535 && max <= 65535 && max >= min);'
+			]
+		},
 		"hostname": {
 			desc: 'hostname',
 			code: [

--- a/renderer/renderer.uc
+++ b/renderer/renderer.uc
@@ -1,5 +1,3 @@
-{%
-
 // UCI batch output master template
 
 "use strict";

--- a/renderer/renderer.uc
+++ b/renderer/renderer.uc
@@ -554,6 +554,30 @@ let ipcalc = {
 		}
 
 		return template;
+	},
+
+	expand_wildcard_address: function(wcaddr, prefix) {
+		let addr = iptoarr(wcaddr),
+		    cidr = match(prefix, /^([0-9a-fA-F:.]+)\/([0-9]+)$/);
+
+		assert(addr, "Invalid wildcard address '" + wcaddr + '"');
+		assert(cidr, "Invalid prefix range '" + prefix + '"');
+
+		let mask = this.convert_bits_to_mask(+cidr[2], length(addr) == 16),
+		    base = this.apply_mask(iptoarr(cidr[1]), mask),
+		    result = [];
+
+		for (let i, b in addr) {
+			if (b & mask[i]) {
+				warn("Wildcard address '" + wcaddr + "' is partially masked by interface subnet mask '" + arrtoip(mask) + '"');
+				break;
+			}
+		}
+
+		for (let i, b in addr)
+			result[i] = base[i] | (b & ~mask[i]);
+
+		return arrtoip(result);
 	}
 };
 

--- a/renderer/renderer.uc
+++ b/renderer/renderer.uc
@@ -409,7 +409,7 @@ let ethernet = {
 	find_interface: function(role, vid) {
 		for (let interface in state.interfaces)
 			if (interface.role == role &&
-			    interface.vlan.id == vid)
+			    interface.vlan?.id == vid)
 				return this.calculate_name(interface);
 		return '';
 	},

--- a/renderer/templates/interface.uc
+++ b/renderer/templates/interface.uc
@@ -65,6 +65,18 @@
 		return;
 	}
 
+	// Port forwardings are only supported on downstream interfaces
+	if ((interface.ipv4?.port_forward || interface.ipv6?.port_forward) && interface.role != 'downstream') {
+		warn("Port forwardings are only supported on downstream interfaces.");
+		return;
+	}
+
+	// Traffic accept rules are only supported on downstream interfaces
+	if (interface.ipv6?.traffic_allow && interface.role != 'downstream') {
+		warn("Traffic accept rules are only supported on downstream interfaces.");
+		return;
+	}
+
 	// Gather related BSS modes and ethernet ports.
 	let bss_modes = map(interface.ssids, ssid => ssid.bss_mode);
 	let eth_ports = ethernet.lookup_by_interface_vlan(interface);

--- a/renderer/templates/interface.uc
+++ b/renderer/templates/interface.uc
@@ -39,7 +39,7 @@
 	}
 
 	// resolve auto prefixes
-	if (interface.ipv4 && interface.ipv4.subnet) {
+	if (wildcard(interface.ipv4?.subnet, 'auto/*')) {
 		try {
 			interface.ipv4.subnet = ipcalc.generate_prefix(state, interface.ipv4.subnet, false);
 		}
@@ -49,7 +49,7 @@
 		}
 	}
 
-	if (interface.ipv6 && interface.ipv6.subnet) {
+	if (wildcard(interface.ipv6?.subnet, 'auto/*')) {
 		try {
 			interface.ipv6.subnet = ipcalc.generate_prefix(state, interface.ipv6.subnet, true);
 		}

--- a/renderer/templates/interface/firewall.uc
+++ b/renderer/templates/interface/firewall.uc
@@ -140,3 +140,32 @@ set firewall.@rule[-1].family='ipv6'
 set firewall.@rule[-1].proto='udp'
 set firewall.@rule[-1].target='ACCEPT'
 {% endif %}
+
+{%
+	for (let forward in interface.ipv4?.port_forward)
+		include('firewall/forward.uc', {
+			forward,
+			family: 'ipv4',
+			source_zone: ethernet.find_interface('upstream', interface.vlan?.id),
+			destination_zone: name,
+			destination_subnet: interface.ipv4.subnet
+		});
+
+	for (let forward in interface.ipv6?.port_forward)
+		include('firewall/forward.uc', {
+			forward,
+			family: 'ipv6',
+			source_zone: ethernet.find_interface('upstream', interface.vlan?.id),
+			destination_zone: name,
+			destination_subnet: interface.ipv6.subnet
+		});
+
+	for (let allow in interface.ipv6?.traffic_allow)
+		include('firewall/allow.uc', {
+			allow,
+			family: 'ipv6',
+			source_zone: ethernet.find_interface('upstream', interface.vlan?.id),
+			destination_zone: name,
+			destination_subnet: interface.ipv6.subnet
+		});
+%}

--- a/renderer/templates/interface/firewall/allow.uc
+++ b/renderer/templates/interface/firewall/allow.uc
@@ -1,0 +1,20 @@
+add firewall rule
+set firewall.@rule[-1].name='Allow traffic to {{ allow.destination_address }}'
+set firewall.@rule[-1].family={{ s(family) }}
+set firewall.@rule[-1].src={{ s(source_zone || '*') }}
+set firewall.@rule[-1].dest={{ s(destination_zone) }}
+{%  for (let proto in ((allow.protocol in ['any', 'all', '*'] && (allow.source_ports || allow.destination_ports)) ? ['tcp', 'udp'] : [ allow.protocol ])): %}
+add_list firewall.@rule[-1].proto={{ s(proto) }}
+{%  endfor %}
+{%  if (allow.source_address): %}
+set firewall.@rule[-1].src_ip={{ s(allow.source_address) }}
+{%  endif %}
+{%  for (let sport in allow.source_ports): %}
+add_list firewall.@rule[-1].src_port={{ s(sport) }}
+{%  endfor %}
+set firewall.@rule[-1].dest_ip={{ ipcalc.expand_wildcard_address(allow.destination_address, destination_subnet) }}
+{%  for (let dport in allow.destination_ports): %}
+add_list firewall.@rule[-1].dest_port={{ s(dport) }}
+{%  endfor %}
+set firewall.@rule[-1].target=ACCEPT
+

--- a/renderer/templates/interface/firewall/forward.uc
+++ b/renderer/templates/interface/firewall/forward.uc
@@ -1,0 +1,15 @@
+{% if (true || source_zone): %}
+add firewall redirect
+set firewall.@redirect[-1].name='Forward port {{ forward.external_port }} to {{ forward.internal_address }}'
+set firewall.@redirect[-1].family={{ s(family) }}
+set firewall.@redirect[-1].src={{ s(source_zone || '*') }}
+set firewall.@redirect[-1].dest={{ s(destination_zone) }}
+{%  for (let proto in ((forward.protocol in ['any', 'all', '*']) ? ['tcp', 'udp'] : [ forward.protocol ])): %}
+add_list firewall.@redirect[-1].proto={{ s(proto) }}
+{%  endfor %}
+set firewall.@redirect[-1].src_dport={{ s(forward.external_port) }}
+set firewall.@redirect[-1].dest_ip={{ ipcalc.expand_wildcard_address(forward.internal_address, destination_subnet) }}
+set firewall.@redirect[-1].dest_port={{ s(forward.internal_port) }}
+set firewall.@redirect[-1].target=DNAT
+
+{% endif %}

--- a/renderer/wifi/iface.uc
+++ b/renderer/wifi/iface.uc
@@ -1,4 +1,3 @@
-{%
 let nl = require("nl80211");
 let def = nl.const;
 
@@ -73,4 +72,3 @@ function lookup_wifs() {
 }
 
 return lookup_wifs();
-%}

--- a/renderer/wifi/phy.uc
+++ b/renderer/wifi/phy.uc
@@ -1,4 +1,3 @@
-{%
 let fs = require('fs');
 let uci = require("uci");
 let cursor = uci ? uci.cursor() : null;
@@ -134,4 +133,3 @@ function lookup_phys() {
 }
 
 return lookup_phys();
-%}

--- a/renderer/wifi/station.uc
+++ b/renderer/wifi/station.uc
@@ -1,4 +1,3 @@
-{%
 let nl = require("nl80211");
 let def = nl.const;
 
@@ -101,4 +100,3 @@ function lookup_stations() {
 }
 
 return lookup_stations();
-%}

--- a/renderer/wifi/survey.uc
+++ b/renderer/wifi/survey.uc
@@ -1,4 +1,3 @@
-{%
 let nl = require("nl80211");
 let def = nl.const;
 let rv = { survey: [] };
@@ -35,4 +34,3 @@ function lookup_survey() {
 lookup_survey();
 //printf('%.J\n', rv);
 return rv;
-%}

--- a/schema/interface.captive.yml
+++ b/schema/interface.captive.yml
@@ -11,7 +11,7 @@ properties:
     description:
       The fqdn used for the captive portal IP.
     type: string
-    format: fqdn
+    format: uc-fqdn
     default: ucentral.splash
   max-clients:
     description:

--- a/schema/interface.ipv4.port-forward.yml
+++ b/schema/interface.ipv4.port-forward.yml
@@ -1,0 +1,41 @@
+description:
+  This section describes an IPv4 port forwarding.
+type: object
+properties:
+  protocol:
+    description:
+      The layer 3 protocol to match.
+    type: string
+    enum:
+      - tcp
+      - udp
+      - any
+    default: any
+  external-port:
+    description:
+      The external port(s) to forward.
+    type:
+      - integer
+      - string
+    minimum: 0
+    maximum: 65535
+    format: uc-portrange
+  internal-address:
+    description:
+      The internal IP to forward to. The address will be masked and concatenated
+      with the effective interface subnet.
+    type: string
+    format: ipv4
+    example: '0.0.0.120'
+  internal-port:
+    description:
+      The internal port to forward to. Defaults to the external port if omitted.
+    type:
+      - integer
+      - string
+    minimum: 0
+    maximum: 65535
+    format: uc-portrange
+required:
+  - external-port
+  - internal-address

--- a/schema/interface.ipv4.yml
+++ b/schema/interface.ipv4.yml
@@ -52,3 +52,7 @@ properties:
     type: array
     items:
       $ref: "https://ucentral.io/schema/v1/interface/ipv4/dhcp-lease/"
+  port-forward:
+    type: array
+    items:
+      $ref: "https://ucentral.io/schema/v1/interface/ipv4/port-forward/"

--- a/schema/interface.ipv6.port-forward.yml
+++ b/schema/interface.ipv6.port-forward.yml
@@ -1,0 +1,41 @@
+description:
+  This section describes an IPv6 port forwarding.
+type: object
+properties:
+  protocol:
+    description:
+      The layer 3 protocol to match.
+    type: string
+    enum:
+      - tcp
+      - udp
+      - any
+    default: any
+  external-port:
+    description:
+      The external port(s) to forward.
+    type:
+      - integer
+      - string
+    minimum: 0
+    maximum: 65535
+    format: uc-portrange
+  internal-address:
+    description:
+      The internal IP to forward to. The address will be masked and concatenated
+      with the effective interface subnet.
+    type: string
+    format: ipv6
+    example: '::1234:abcd'
+  internal-port:
+    description:
+      The internal port to forward to. Defaults to the external port if omitted.
+    type:
+      - integer
+      - string
+    minimum: 0
+    maximum: 65535
+    format: uc-portrange
+required:
+  - external-port
+  - internal-address

--- a/schema/interface.ipv6.traffic-allow.yml
+++ b/schema/interface.ipv6.traffic-allow.yml
@@ -1,0 +1,49 @@
+description:
+  This section describes an IPv6 traffic accept rule.
+type: object
+properties:
+  protocol:
+    description:
+      The layer 3 protocol to match.
+    type: string
+    default: any
+  source-address:
+    description:
+      The source IP to allow traffic from.
+    type: string
+    format: uc-cidr6
+    example: 2001:db8:1234:abcd::/64
+    default: ::/0
+  source-ports:
+    description:
+      The source port(s) to accept.
+    type: array
+    minItems: 1
+    items:
+      type:
+        - integer
+        - string
+      minimum: 0
+      maximum: 65535
+      format: uc-portrange
+  destination-address:
+    description:
+      The destination IP to allow traffic to. The address will be masked and
+      concatenated with the effective interface subnet.
+    type: string
+    format: ipv6
+    example: ::1000
+  destination-ports:
+    description:
+      The destination ports to accept.
+    type: array
+    minItems: 1
+    items:
+      type:
+        - integer
+        - string
+      minimum: 0
+      maximum: 65535
+      format: uc-portrange
+required:
+  - destination-address

--- a/schema/interface.ipv6.yml
+++ b/schema/interface.ipv6.yml
@@ -50,3 +50,11 @@ properties:
     minimum: 0
   dhcpv6:
     $ref: "https://ucentral.io/schema/v1/interface/ipv6/dhcpv6/"
+  port-forward:
+    type: array
+    items:
+      $ref: "https://ucentral.io/schema/v1/interface/ipv6/port-forward/"
+  traffic-allow:
+    type: array
+    items:
+      $ref: "https://ucentral.io/schema/v1/interface/ipv6/traffic-allow/"

--- a/schema/service.quality-of-service.yml
+++ b/schema/service.quality-of-service.yml
@@ -91,7 +91,7 @@ properties:
             properties:
               fqdn:
                 type: string
-                format: fqdn
+                format: uc-fqdn
               suffix-matching:
                 description:
                   Match for all suffixes of the FQDN.

--- a/schemareader.uc
+++ b/schemareader.uc
@@ -44,7 +44,7 @@ function matchHostname(value) {
 	return (length(filter(labels, label => !match(label, /^([a-zA-Z0-9]{1,2}|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9])$/))) == 0 && length(labels) > 0);
 }
 
-function matchFqdn(value) {
+function matchUcFqdn(value) {
 	if (length(value) > 255) return false;
 	let labels = split(value, ".");
 	return (length(filter(labels, label => !match(label, /^([a-zA-Z0-9]{1,2}|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9])$/))) == 0 && length(labels) > 1);
@@ -1984,7 +1984,7 @@ function instantiateInterfaceCaptive(location, value, errors) {
 
 		function parseGatewayFqdn(location, value, errors) {
 			if (type(value) == "string") {
-				if (!matchFqdn(value))
+				if (!matchUcFqdn(value))
 					push(errors, [ location, "must be a valid fully qualified domain name" ]);
 
 			}
@@ -5756,7 +5756,7 @@ function instantiateServiceQualityOfService(location, value, errors) {
 
 										function parseFqdn(location, value, errors) {
 											if (type(value) == "string") {
-												if (!matchFqdn(value))
+												if (!matchUcFqdn(value))
 													push(errors, [ location, "must be a valid fully qualified domain name" ]);
 
 											}

--- a/schemareader.uc
+++ b/schemareader.uc
@@ -1,4 +1,3 @@
-{%
 // Automatically generated from ./ucentral.schema.pretty.json - do not edit!
 "use strict";
 

--- a/selftest.sh
+++ b/selftest.sh
@@ -6,7 +6,7 @@ if [ -n "$1" ]; then
 else
 	./generate-example.uc > input.json
 fi
-ucode -s '{%
+cat <<EOT | ucode -R -
 	push(REQUIRE_SEARCH_PATH,
 		"/usr/local/lib/ucode/*.so",
 		"tests/lib/*.uc",
@@ -42,4 +42,4 @@ ucode -s '{%
 	catch (e) {
 		warn("Fatal error while generating UCI: ", e, "\n", e.stacktrace[0].context, "\n");
 	}
-%}'
+EOT

--- a/tests/lib/mocklib.uc
+++ b/tests/lib/mocklib.uc
@@ -179,6 +179,7 @@ global.mocklib = {
 
 		try {
 			res = require(module);
+			delete global.modules[module];
 		}
 		catch (e) {
 			ex = e;

--- a/tests/lib/mocklib.uc
+++ b/tests/lib/mocklib.uc
@@ -1,225 +1,227 @@
-{%
-	let _fs = require("fs");
+let _fs = require("fs");
 
-	let _log = (level, fmt, ...args) => {
-		let color, prefix;
+/* Force reloading fs module on next require */
+delete global.modules.fs;
 
-		switch (level) {
-		case 'info':
-			color = 34;
-			prefix = '!';
-			break;
+let _log = (level, fmt, ...args) => {
+	let color, prefix;
 
-		case 'warn':
-			color = 33;
-			prefix = 'W';
-			break;
-
-		case 'error':
-			color = 31;
-			prefix = 'E';
-			break;
-
-		default:
-			color = 0;
-			prefix = 'I';
-		}
-
-		let f = sprintf("\u001b[%d;1m[%s] %s\u001b[0m", color, prefix, fmt);
-		warn(replace(sprintf(f, ...args), "\n", "\n    "), "\n");
-	};
-
-	let read_data_file = (path) => {
-		for (let dir in MOCK_SEARCH_PATH) {
-			let fd = _fs.open(dir + '/' + path, "r");
-
-			if (fd) {
-				let data = fd.read("all");
-				fd.close();
-
-				return data;
-			}
-		}
-
-		return null;
-	};
-
-	let read_json_file = (path) => {
-		let data = read_data_file(path);
-
-		if (data != null)  {
-			try {
-				return json(data);
-			}
-			catch (e) {
-				_log('error', "Unable to parse JSON data in %s: %s", path, e);
-
-				return NaN;
-			}
-		}
-
-		return null;
-	};
-
-	let format_json = (data) => {
-		let rv;
-
-		let format_value = (value) => {
-			switch (type(value)) {
-			case "object":
-				return sprintf("{ /* %d keys */ }", length(value));
-
-			case "array":
-				return sprintf("[ /* %d items */ ]", length(value));
-
-			case "string":
-				if (length(value) > 64)
-					value = substr(value, 0, 64) + "...";
-
-				/* fall through */
-				return sprintf("%J", value);
-
-			default:
-				return sprintf("%J", value);
-			}
-		};
-
-		switch (type(data)) {
-		case "object":
-			rv = "{";
-
-			let k = sort(keys(data));
-
-			for (let i, n in k)
-				rv += sprintf("%s %J: %s", i ? "," : "", n, format_value(data[n]));
-
-			rv += " }";
-			break;
-
-		case "array":
-			rv = "[";
-
-			for (let i, v in data)
-				rv += (i ? "," : "") + " " + format_value(v);
-
-			rv += " ]";
-			break;
-
-		default:
-			rv = format_value(data);
-		}
-
-		return rv;
-	};
-
-	let trace_call = (ns, func, args) => {
-		let msg = "[call] " +
-			(ns ? ns + "." : "") +
-			func;
-
-		for (let k, v in args) {
-			msg += ' ' + k + ' <';
-
-			switch (type(v)) {
-			case "array":
-			case "object":
-				msg += format_json(v);
-				break;
-
-			default:
-				msg += v;
-			}
-
-			msg += '>';
-		}
-
-		switch (TRACE_CALLS) {
-		case '1':
-		case 'stdout':
-			_fs.stdout.write(msg + "\n");
-			break;
-
-		case 'stderr':
-			_fs.stderr.write(msg + "\n");
-			break;
-		}
-	};
-
-	/* Prepend mocklib to REQUIRE_SEARCH_PATH */
-	for (let pattern in REQUIRE_SEARCH_PATH) {
-		/* Only consider ucode includes */
-		if (!match(pattern, /\*\.uc$/))
-			continue;
-
-		let path = replace(pattern, /\*/, 'mocklib'),
-		    stat = _fs.stat(path);
-
-		if (!stat || stat.type != 'file')
-			continue;
-
-		if (type(MOCK_SEARCH_PATH) != 'array' || length(MOCK_SEARCH_PATH) == 0)
-			MOCK_SEARCH_PATH = [ replace(path, /mocklib\.uc$/, '../mocks') ];
-
-		unshift(REQUIRE_SEARCH_PATH, replace(path, /mocklib\.uc$/, 'mocklib/*.uc'));
+	switch (level) {
+	case 'info':
+		color = 34;
+		prefix = '!';
 		break;
+
+	case 'warn':
+		color = 33;
+		prefix = 'W';
+		break;
+
+	case 'error':
+		color = 31;
+		prefix = 'E';
+		break;
+
+	default:
+		color = 0;
+		prefix = 'I';
 	}
 
+	let f = sprintf("\u001b[%d;1m[%s] %s\u001b[0m", color, prefix, fmt);
+	warn(replace(sprintf(f, ...args), "\n", "\n    "), "\n");
+};
+
+let read_data_file = (path) => {
+	for (let dir in MOCK_SEARCH_PATH) {
+		let fd = _fs.open(dir + '/' + path, "r");
+
+		if (fd) {
+			let data = fd.read("all");
+			fd.close();
+
+			return data;
+		}
+	}
+
+	return null;
+};
+
+let read_json_file = (path) => {
+	let data = read_data_file(path);
+
+	if (data != null)  {
+		try {
+			return json(data);
+		}
+		catch (e) {
+			_log('error', "Unable to parse JSON data in %s: %s", path, e);
+
+			return NaN;
+		}
+	}
+
+	return null;
+};
+
+let format_json = (data) => {
+	let rv;
+
+	let format_value = (value) => {
+		switch (type(value)) {
+		case "object":
+			return sprintf("{ /* %d keys */ }", length(value));
+
+		case "array":
+			return sprintf("[ /* %d items */ ]", length(value));
+
+		case "string":
+			if (length(value) > 64)
+				value = substr(value, 0, 64) + "...";
+
+			/* fall through */
+			return sprintf("%J", value);
+
+		default:
+			return sprintf("%J", value);
+		}
+	};
+
+	switch (type(data)) {
+	case "object":
+		rv = "{";
+
+		let k = sort(keys(data));
+
+		for (let i, n in k)
+			rv += sprintf("%s %J: %s", i ? "," : "", n, format_value(data[n]));
+
+		rv += " }";
+		break;
+
+	case "array":
+		rv = "[";
+
+		for (let i, v in data)
+			rv += (i ? "," : "") + " " + format_value(v);
+
+		rv += " ]";
+		break;
+
+	default:
+		rv = format_value(data);
+	}
+
+	return rv;
+};
+
+let trace_call = (ns, func, args) => {
+	let msg = "[call] " +
+		(ns ? ns + "." : "") +
+		func;
+
+	for (let k, v in args) {
+		msg += ' ' + k + ' <';
+
+		switch (type(v)) {
+		case "array":
+		case "object":
+			msg += format_json(v);
+			break;
+
+		default:
+			msg += v;
+		}
+
+		msg += '>';
+	}
+
+	switch (TRACE_CALLS) {
+	case '1':
+	case 'stdout':
+		_fs.stdout.write(msg + "\n");
+		break;
+
+	case 'stderr':
+		_fs.stderr.write(msg + "\n");
+		break;
+	}
+};
+
+/* Prepend mocklib to REQUIRE_SEARCH_PATH */
+for (let pattern in REQUIRE_SEARCH_PATH) {
+	/* Only consider ucode includes */
+	if (!match(pattern, /\*\.uc$/))
+		continue;
+
+	let path = replace(pattern, /\*/, 'mocklib'),
+	    stat = _fs.stat(path);
+
+	if (!stat || stat.type != 'file')
+		continue;
+
 	if (type(MOCK_SEARCH_PATH) != 'array' || length(MOCK_SEARCH_PATH) == 0)
-		MOCK_SEARCH_PATH = [ './mocks' ];
+		MOCK_SEARCH_PATH = [ replace(path, /mocklib\.uc$/, '../mocks') ];
 
-	/* Register global mocklib namespace */
-	global.mocklib = {
-		require: function(module) {
-			let path, res, ex;
+	unshift(REQUIRE_SEARCH_PATH, replace(path, /mocklib\.uc$/, 'mocklib/*.uc'));
+	break;
+}
 
-			if (type(REQUIRE_SEARCH_PATH) == "array" && index(REQUIRE_SEARCH_PATH[0], 'mocklib/*.uc') != -1)
-				path = shift(REQUIRE_SEARCH_PATH);
+if (type(MOCK_SEARCH_PATH) != 'array' || length(MOCK_SEARCH_PATH) == 0)
+	MOCK_SEARCH_PATH = [ './mocks' ];
 
-			try {
-				res = require(module);
-			}
-			catch (e) {
-				ex = e;
-			}
+/* Register global mocklib namespace */
+global.mocklib = {
+	require: function(module) {
+		let path, res, ex;
 
-			if (path)
-				unshift(REQUIRE_SEARCH_PATH, path);
+		if (type(REQUIRE_SEARCH_PATH) == "array" && index(REQUIRE_SEARCH_PATH[0], 'mocklib/*.uc') != -1)
+			path = shift(REQUIRE_SEARCH_PATH);
 
-			if (ex)
-				die(ex);
+		try {
+			res = require(module);
+		}
+		catch (e) {
+			ex = e;
+		}
 
-			return res;
-		},
+		if (path)
+			unshift(REQUIRE_SEARCH_PATH, path);
 
-		I: (...args) => _log('info', ...args),
-		N: (...args) => _log('notice', ...args),
-		W: (...args) => _log('warn', ...args),
-		E: (...args) => _log('error', ...args),
+		if (ex)
+			die(ex);
 
-		format_json,
-		read_data_file,
-		read_json_file,
-		trace_call
-	};
+		return res;
+	},
 
-	/* Override stdlib functions */
-	global.system = function(argv, timeout) {
-		trace_call(null, "system", { command: argv, timeout });
+	I: (...args) => _log('info', ...args),
+	N: (...args) => _log('notice', ...args),
+	W: (...args) => _log('warn', ...args),
+	E: (...args) => _log('error', ...args),
 
-		return 0;
-	};
+	format_json,
+	read_data_file,
+	read_json_file,
+	trace_call
+};
 
-	global.time = function() {
-		trace_call(null, "time");
+/* Override stdlib functions */
+global.system = function(argv, timeout) {
+	trace_call(null, "system", { command: argv, timeout });
 
-		return 1615382640;
-	};
+	return 0;
+};
 
-	global.print = function(...args) {
-		if (length(args) == 1 && type(args[0]) in ["array", "object"])
-			printf("%s\n", format_json(args[0]));
-		else
-			global.print(...args);
-	};
+global.time = function() {
+	trace_call(null, "time");
 
-	return global.mocklib;
+	return 1615382640;
+};
+
+global.print = function(...args) {
+	if (length(args) == 1 && type(args[0]) in ["array", "object"])
+		printf("%s\n", format_json(args[0]));
+	else
+		global.print(...args);
+};
+
+return global.mocklib;

--- a/tests/lib/mocklib/fs.uc
+++ b/tests/lib/mocklib/fs.uc
@@ -1,181 +1,180 @@
-{%
-	let mocklib = global.mocklib,
-	    fs = mocklib.require("fs");
+let mocklib = global.mocklib,
+    fs = mocklib.require("fs");
 
-	return {
-		readlink: function(path) {
-			mocklib.trace_call("fs", "readlink", { path });
+return {
+	readlink: function(path) {
+		mocklib.trace_call("fs", "readlink", { path });
 
-			return path + "-link";
-		},
+		return path + "-link";
+	},
 
-		stat: function(path) {
-			let file = sprintf("fs/stat~%s.json", replace(path, /[^A-Za-z0-9_-]+/g, '_')),
-			    mock = mocklib.read_json_file(file);
+	stat: function(path) {
+		let file = sprintf("fs/stat~%s.json", replace(path, /[^A-Za-z0-9_-]+/g, '_')),
+		    mock = mocklib.read_json_file(file);
 
-			if (!mock || mock != mock) {
-				mocklib.I("No stat result fixture defined for fs.stat() call on %s.", path);
-				mocklib.I("Provide a mock result through the following JSON file:\n%s\n", file);
+		if (!mock || mock != mock) {
+			mocklib.I("No stat result fixture defined for fs.stat() call on %s.", path);
+			mocklib.I("Provide a mock result through the following JSON file:\n%s\n", file);
 
-				if (match(path, /\/$/))
-					mock = { type: "directory" };
-				else
-					mock = { type: "file" };
-			}
+			if (match(path, /\/$/))
+				mock = { type: "directory" };
+			else
+				mock = { type: "file" };
+		}
 
-			mocklib.trace_call("fs", "stat", { path });
+		mocklib.trace_call("fs", "stat", { path });
 
-			return mock;
-		},
+		return mock;
+	},
 
-		unlink: function(path) {
-			printf("fs.unlink() path <%s>\n", path);
+	unlink: function(path) {
+		printf("fs.unlink() path <%s>\n", path);
 
-			return true;
-		},
+		return true;
+	},
 
-		popen: (cmdline, mode) => {
-			let read = (!mode || index(mode, "r") != -1),
-			    path = sprintf("fs/popen~%s.txt", replace(cmdline, /[^A-Za-z0-9_-]+/g, '_')),
-			    mock = mocklib.read_data_file(path);
+	popen: (cmdline, mode) => {
+		let read = (!mode || index(mode, "r") != -1),
+		    path = sprintf("fs/popen~%s.txt", replace(cmdline, /[^A-Za-z0-9_-]+/g, '_')),
+		    mock = mocklib.read_data_file(path);
 
-			if (read && !mock) {
-				mocklib.I("No stdout fixture defined for fs.popen() command %s.", cmdline);
-				mocklib.I("Provide a mock output through the following text file:\n%s\n", path);
+		if (read && !mock) {
+			mocklib.I("No stdout fixture defined for fs.popen() command %s.", cmdline);
+			mocklib.I("Provide a mock output through the following text file:\n%s\n", path);
 
+			return null;
+		}
+
+		mocklib.trace_call("fs", "popen", { cmdline, mode });
+
+		return {
+			read: function(amount) {
+				let rv;
+
+				switch (amount) {
+				case "all":
+					rv = mock;
+					mock = "";
+					break;
+
+				case "line":
+					let i = index(mock, "\n");
+					i = (i > -1) ? i + 1 : mock.length;
+					rv = substr(mock, 0, i);
+					mock = substr(mock, i);
+					break;
+
+				default:
+					let n = +amount;
+					n = (n > 0) ? n : 0;
+					rv = substr(mock, 0, n);
+					mock = substr(mock, n);
+					break;
+				}
+
+				return rv;
+			},
+
+			write: function() {},
+			close: function() {},
+
+			error: function() {
 				return null;
 			}
+		};
+	},
 
-			mocklib.trace_call("fs", "popen", { cmdline, mode });
+	open: (fpath, mode) => {
+		let read = (!mode || index(mode, "r") != -1 || index(mode, "+") != -1),
+		    path = sprintf("fs/open~%s.txt", replace(fpath, /[^A-Za-z0-9_-]+/g, '_')),
+		    mock = read ? mocklib.read_data_file(path) : null;
 
-			return {
-				read: function(amount) {
-					let rv;
+		if (read && !mock) {
+			mocklib.I("No stdout fixture defined for fs.open() path %s.", fpath);
+			mocklib.I("Provide a mock output through the following text file:\n%s\n", path);
 
-					switch (amount) {
-					case "all":
-						rv = mock;
-						mock = "";
-						break;
+			return null;
+		}
 
-					case "line":
-						let i = index(mock, "\n");
-						i = (i > -1) ? i + 1 : mock.length;
-						rv = substr(mock, 0, i);
-						mock = substr(mock, i);
-						break;
+		mocklib.trace_call("fs", "open", { path: fpath, mode });
 
-					default:
-						let n = +amount;
-						n = (n > 0) ? n : 0;
-						rv = substr(mock, 0, n);
-						mock = substr(mock, n);
-						break;
-					}
+		return {
+			read: function(amount) {
+				let rv;
 
-					return rv;
-				},
+				switch (amount) {
+				case "all":
+					rv = mock;
+					mock = "";
+					break;
 
-				write: function() {},
-				close: function() {},
+				case "line":
+					let i = index(mock, "\n");
+					i = (i > -1) ? i + 1 : length(mock);
+					rv = substr(mock, 0, i);
+					mock = substr(mock, i);
+					break;
 
-				error: function() {
-					return null;
+				default:
+					let n = +amount;
+					n = (n > 0) ? n : 0;
+					rv = substr(mock, 0, n);
+					mock = substr(mock, n);
+					break;
 				}
-			};
-		},
 
-		open: (fpath, mode) => {
-			let read = (!mode || index(mode, "r") != -1 || index(mode, "+") != -1),
-			    path = sprintf("fs/open~%s.txt", replace(fpath, /[^A-Za-z0-9_-]+/g, '_')),
-			    mock = read ? mocklib.read_data_file(path) : null;
+				return rv;
+			},
 
-			if (read && !mock) {
-				mocklib.I("No stdout fixture defined for fs.open() path %s.", fpath);
-				mocklib.I("Provide a mock output through the following text file:\n%s\n", path);
+			write: function() {},
+			close: function() {},
 
+			error: function() {
 				return null;
 			}
+		};
+	},
 
-			mocklib.trace_call("fs", "open", { path: fpath, mode });
+	glob: (...patterns) => {
+		let rv = [];
 
-			return {
-				read: function(amount) {
-					let rv;
+		for (let pattern in patterns) {
+			let parts = split(pattern, '/'),
+			    candidates = [],
+			    found = false;
 
-					switch (amount) {
-					case "all":
-						rv = mock;
-						mock = "";
-						break;
+			for (let i = length(parts); i > 0; i--) {
+				let file = sprintf("fs/glob~%s.json", replace(join('/', parts), /[^A-Za-z0-9_-]+/g, '_')),
+				    mock = mocklib.read_json_file(file);
 
-					case "line":
-						let i = index(mock, "\n");
-						i = (i > -1) ? i + 1 : length(mock);
-						rv = substr(mock, 0, i);
-						mock = substr(mock, i);
-						break;
+				push(candidates, file);
+				shift(parts);
 
-					default:
-						let n = +amount;
-						n = (n > 0) ? n : 0;
-						rv = substr(mock, 0, n);
-						mock = substr(mock, n);
-						break;
+				if (mock) {
+					if (mock != mock) {
+						mocklib.W("Invalid JSON in mock file %s\n", file);
+						continue;
 					}
 
-					return rv;
-				},
-
-				write: function() {},
-				close: function() {},
-
-				error: function() {
-					return null;
-				}
-			};
-		},
-
-		glob: (...patterns) => {
-			let rv = [];
-
-			for (let pattern in patterns) {
-				let parts = split(pattern, '/'),
-				    candidates = [],
-				    found = false;
-
-				for (let i = length(parts); i > 0; i--) {
-					let file = sprintf("fs/glob~%s.json", replace(join('/', parts), /[^A-Za-z0-9_-]+/g, '_')),
-					    mock = mocklib.read_json_file(file);
-
-					push(candidates, file);
-					shift(parts);
-
-					if (mock) {
-						if (mock != mock) {
-							mocklib.W("Invalid JSON in mock file %s\n", file);
-							continue;
-						}
-
-						if (type(mock) != "array") {
-							mocklib.W("Expecting an array in JSON mock file %s\n", file);
-							continue;
-						}
-
-						push(rv, ...mock);
-						found = true;
-						break;
+					if (type(mock) != "array") {
+						mocklib.W("Expecting an array in JSON mock file %s\n", file);
+						continue;
 					}
-				}
 
-				if (!found) {
-					mocklib.I("No glob result fixture defined for fs.glob() call with pattern %s.", pattern);
-					mocklib.I("Provide a mock result through one of the following JSON files:\n%s\n", join("\n", candidates));
+					push(rv, ...mock);
+					found = true;
+					break;
 				}
 			}
 
-			return rv;
-		},
+			if (!found) {
+				mocklib.I("No glob result fixture defined for fs.glob() call with pattern %s.", pattern);
+				mocklib.I("Provide a mock result through one of the following JSON files:\n%s\n", join("\n", candidates));
+			}
+		}
 
-		error: () => "Unspecified error"
-	};
+		return rv;
+	},
+
+	error: () => "Unspecified error"
+};

--- a/tests/lib/mocklib/ubus.uc
+++ b/tests/lib/mocklib/ubus.uc
@@ -1,69 +1,68 @@
-{%
-	let mocklib = global.mocklib;
+let mocklib = global.mocklib;
 
-	return {
-		connect: function() {
-			let self = this;
+return {
+	connect: function() {
+		let self = this;
 
-			return {
-				call: (object, method, args) => {
-					let signature = [ object + "~" + method ];
+		return {
+			call: (object, method, args) => {
+				let signature = [ object + "~" + method ];
 
-					if (type(args) == "object") {
-						for (let i, k in sort(keys(args))) {
-							switch (type(args[k])) {
-							case "string":
-							case "double":
-							case "bool":
-							case "int":
-								push(signature, k + "-" + replace(args[k], /[^A-Za-z0-9_-]+/g, "_"));
-								break;
+				if (type(args) == "object") {
+					for (let i, k in sort(keys(args))) {
+						switch (type(args[k])) {
+						case "string":
+						case "double":
+						case "bool":
+						case "int":
+							push(signature, k + "-" + replace(args[k], /[^A-Za-z0-9_-]+/g, "_"));
+							break;
 
-							default:
-								push(signature, type(args[k]));
-							}
+						default:
+							push(signature, type(args[k]));
 						}
 					}
+				}
 
-					let candidates = [];
+				let candidates = [];
 
-					for (let i = length(signature); i > 0; i--) {
-						let path = sprintf("ubus/%s.json", join("~", signature)),
-						    mock = mocklib.read_json_file(path);
+				for (let i = length(signature); i > 0; i--) {
+					let path = sprintf("ubus/%s.json", join("~", signature)),
+					    mock = mocklib.read_json_file(path);
 
-						if (mock != mock) {
-							self._error = "Invalid argument";
+					if (mock != mock) {
+						self._error = "Invalid argument";
 
-							return null;
-						}
-						else if (mock) {
-							mocklib.trace_call("ubusconn", "call", { object, method, args });
+						return null;
+					}
+					else if (mock) {
+						mocklib.trace_call("ubusconn", "call", { object, method, args });
 
-							return mock;
-						}
-
-						push(candidates, path);
-						pop(signature);
+						return mock;
 					}
 
-					mocklib.I("No response fixture defined for ubus call %s/%s with arguments %s.", object, method, args);
-					mocklib.I("Provide a mock response through one of the following JSON files:\n%s\n", join("\n", candidates));
+					push(candidates, path);
+					pop(signature);
+				}
 
-					self._error = "Method not found";
+				mocklib.I("No response fixture defined for ubus call %s/%s with arguments %s.", object, method, args);
+				mocklib.I("Provide a mock response through one of the following JSON files:\n%s\n", join("\n", candidates));
 
-					return null;
-				},
+				self._error = "Method not found";
 
-				disconnect: () => null,
+				return null;
+			},
 
-				error: () => self.error()
-			};
-		},
+			disconnect: () => null,
 
-		error: function() {
-			let e = this._error;
-			delete(this._error);
+			error: () => self.error()
+		};
+	},
 
-			return e;
-		}
-	};
+	error: function() {
+		let e = this._error;
+		delete(this._error);
+
+		return e;
+	}
+};

--- a/tests/lib/mocklib/uci.uc
+++ b/tests/lib/mocklib/uci.uc
@@ -1,153 +1,152 @@
-{%
-	let mocklib = global.mocklib;
+let mocklib = global.mocklib;
 
-	let byte = (str, off) => {
-		let v = ord(str, off);
-		return length(v) ? v[0] : v;
-	};
+let byte = (str, off) => {
+	let v = ord(str, off);
+	return length(v) ? v[0] : v;
+};
 
-	let hash = (s) => {
-		let h = 7;
+let hash = (s) => {
+	let h = 7;
 
-		for (let i = 0; i < length(s); i++)
-			h = h * 31 + byte(s, i);
+	for (let i = 0; i < length(s); i++)
+		h = h * 31 + byte(s, i);
 
-		return h;
-	};
+	return h;
+};
 
-	let id = (config, t, n) => {
-		while (true) {
-			let id = sprintf('cfg%08x', hash(t + n));
+let id = (config, t, n) => {
+	while (true) {
+		let id = sprintf('cfg%08x', hash(t + n));
 
-			if (!exists(config, id))
-				return id;
+		if (!exists(config, id))
+			return id;
 
-			n++;
-		}
-	};
+		n++;
+	}
+};
 
-	let fixup_config = (config) => {
-		let rv = {};
+let fixup_config = (config) => {
+	let rv = {};
 
-		for (let stype in config) {
-			switch (type(config[stype])) {
-			case 'object':
-				config[stype] = [ config[stype] ];
-				/* fall through */
+	for (let stype in config) {
+		switch (type(config[stype])) {
+		case 'object':
+			config[stype] = [ config[stype] ];
+			/* fall through */
 
-			case 'array':
-				for (let idx, sobj in config[stype]) {
-					let sid, anon;
+		case 'array':
+			for (let idx, sobj in config[stype]) {
+				let sid, anon;
 
-					if (exists(sobj, '.name') && !exists(rv, sobj['.name'])) {
-						sid = sobj['.name'];
-						anon = false;
-					}
-					else {
-						sid = id(rv, stype, idx);
-						anon = true;
-					}
-
-					rv[sid] = {
-						'.index': n_section++,
-						...sobj,
-						'.name': sid,
-						'.type': stype,
-						'.anonymous': anon
-					};
+				if (exists(sobj, '.name') && !exists(rv, sobj['.name'])) {
+					sid = sobj['.name'];
+					anon = false;
+				}
+				else {
+					sid = id(rv, stype, idx);
+					anon = true;
 				}
 
-				break;
+				rv[sid] = {
+					'.index': n_section++,
+					...sobj,
+					'.name': sid,
+					'.type': stype,
+					'.anonymous': anon
+				};
 			}
+
+			break;
 		}
+	}
 
-		for (let n, sid in sort(keys(rv), (a, b) => rv[a]['.index'] - rv[b]['.index']))
-			rv[sid]['.index'] = n;
+	for (let n, sid in sort(keys(rv), (a, b) => rv[a]['.index'] - rv[b]['.index']))
+		rv[sid]['.index'] = n;
 
-		return rv;
-	};
+	return rv;
+};
 
-	return {
-		cursor: () => ({
-			_configs: {},
+return {
+	cursor: () => ({
+		_configs: {},
 
-			load: function(file) {
-				let basename = replace(file, /^.+\//, ''),
-				    path = sprintf("uci/%s.json", basename),
-				    mock = mocklib.read_json_file(path);
+		load: function(file) {
+			let basename = replace(file, /^.+\//, ''),
+			    path = sprintf("uci/%s.json", basename),
+			    mock = mocklib.read_json_file(path);
 
-				if (!mock || mock != mock) {
-					mocklib.I("No configuration fixture defined for uci package %s.", file);
-					mocklib.I("Provide a mock configuration through the following JSON file:\n%s\n", path);
+			if (!mock || mock != mock) {
+				mocklib.I("No configuration fixture defined for uci package %s.", file);
+				mocklib.I("Provide a mock configuration through the following JSON file:\n%s\n", path);
 
+				return null;
+			}
+
+			this._configs[basename] = fixup_config(mock);
+		},
+
+		_get_section: function(config, section) {
+			if (!exists(this._configs, config)) {
+				this.load(config);
+
+				if (!exists(this._configs, config))
 					return null;
-				}
+			}
 
-				this._configs[basename] = fixup_config(mock);
-			},
+			let cfg = this._configs[config],
+			    extended = match(section, "^@([A-Za-z0-9_-]+)\[(-?[0-9]+)\]$");
 
-			_get_section: function(config, section) {
-				if (!exists(this._configs, config)) {
-					this.load(config);
+			if (extended) {
+				let stype = extended[1],
+				    sindex = +extended[2];
 
-					if (!exists(this._configs, config))
-						return null;
-				}
+				let sids = sort(
+					filter(keys(cfg), sid => cfg[sid]['.type'] == stype),
+					(a, b) => cfg[a]['.index'] - cfg[b]['.index']
+				);
 
+				if (sindex < 0)
+					sindex = sids.length + sindex;
+
+				return cfg[sids[sindex]];
+			}
+
+			return cfg[section];
+		},
+
+		get: function(config, section, option) {
+			let sobj = this._get_section(config, section);
+
+			if (option && index(option, ".") == 0)
+				return null;
+			else if (sobj && option)
+				return sobj[option];
+			else if (sobj)
+				return sobj[".type"];
+		},
+
+		get_all: function(config, section) {
+			return section ? this._get_section(config, section) : this._configs[config];
+		},
+
+		foreach: function(config, stype, cb) {
+			let rv = false;
+
+			if (exists(this._configs, config)) {
 				let cfg = this._configs[config],
-				    extended = match(section, "^@([A-Za-z0-9_-]+)\[(-?[0-9]+)\]$");
+				    sids = sort(keys(cfg), (a, b) => cfg[a]['.index'] - cfg[b]['.index']);
 
-				if (extended) {
-					let stype = extended[1],
-					    sindex = +extended[2];
+				for (let i, sid in sids) {
+					if (stype == null || cfg[sid]['.type'] == stype) {
+						if (cb({ ...(cfg[sid]) }) === false)
+							break;
 
-					let sids = sort(
-						filter(keys(cfg), sid => cfg[sid]['.type'] == stype),
-						(a, b) => cfg[a]['.index'] - cfg[b]['.index']
-					);
-
-					if (sindex < 0)
-						sindex = sids.length + sindex;
-
-					return cfg[sids[sindex]];
-				}
-
-				return cfg[section];
-			},
-
-			get: function(config, section, option) {
-				let sobj = this._get_section(config, section);
-
-				if (option && index(option, ".") == 0)
-					return null;
-				else if (sobj && option)
-					return sobj[option];
-				else if (sobj)
-					return sobj[".type"];
-			},
-
-			get_all: function(config, section) {
-				return section ? this._get_section(config, section) : this._configs[config];
-			},
-
-			foreach: function(config, stype, cb) {
-				let rv = false;
-
-				if (exists(this._configs, config)) {
-					let cfg = this._configs[config],
-					    sids = sort(keys(cfg), (a, b) => cfg[a]['.index'] - cfg[b]['.index']);
-
-					for (let i, sid in sids) {
-						if (stype == null || cfg[sid]['.type'] == stype) {
-							if (cb({ ...(cfg[sid]) }) === false)
-								break;
-
-							rv = true;
-						}
+						rv = true;
 					}
 				}
-
-				return rv;
 			}
-		})
-	};
+
+			return rv;
+		}
+	})
+};

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -652,6 +652,47 @@
                 }
             }
         },
+        "interface.ipv4.port-forward": {
+            "type": "object",
+            "properties": {
+                "protocol": {
+                    "type": "string",
+                    "enum": [
+                        "tcp",
+                        "udp",
+                        "any"
+                    ],
+                    "default": "any"
+                },
+                "external-port": {
+                    "type": [
+                        "integer",
+                        "string"
+                    ],
+                    "minimum": 0,
+                    "maximum": 65535,
+                    "format": "uc-portrange"
+                },
+                "internal-address": {
+                    "type": "string",
+                    "format": "ipv4",
+                    "example": "0.0.0.120"
+                },
+                "internal-port": {
+                    "type": [
+                        "integer",
+                        "string"
+                    ],
+                    "minimum": 0,
+                    "maximum": 65535,
+                    "format": "uc-portrange"
+                }
+            },
+            "required": [
+                "external-port",
+                "internal-address"
+            ]
+        },
         "interface.ipv4": {
             "type": "object",
             "properties": {
@@ -705,6 +746,12 @@
                     "items": {
                         "$ref": "#/$defs/interface.ipv4.dhcp-lease"
                     }
+                },
+                "port-forward": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/interface.ipv4.port-forward"
+                    }
                 }
             }
         },
@@ -733,6 +780,96 @@
                     "default": "::/0"
                 }
             }
+        },
+        "interface.ipv6.port-forward": {
+            "type": "object",
+            "properties": {
+                "protocol": {
+                    "type": "string",
+                    "enum": [
+                        "tcp",
+                        "udp",
+                        "any"
+                    ],
+                    "default": "any"
+                },
+                "external-port": {
+                    "type": [
+                        "integer",
+                        "string"
+                    ],
+                    "minimum": 0,
+                    "maximum": 65535,
+                    "format": "uc-portrange"
+                },
+                "internal-address": {
+                    "type": "string",
+                    "format": "ipv6",
+                    "example": "::1234:abcd"
+                },
+                "internal-port": {
+                    "type": [
+                        "integer",
+                        "string"
+                    ],
+                    "minimum": 0,
+                    "maximum": 65535,
+                    "format": "uc-portrange"
+                }
+            },
+            "required": [
+                "external-port",
+                "internal-address"
+            ]
+        },
+        "interface.ipv6.traffic-allow": {
+            "type": "object",
+            "properties": {
+                "protocol": {
+                    "type": "string",
+                    "default": "any"
+                },
+                "source-address": {
+                    "type": "string",
+                    "format": "uc-cidr6",
+                    "example": "2001:db8:1234:abcd::/64",
+                    "default": "::/0"
+                },
+                "source-ports": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": [
+                            "integer",
+                            "string"
+                        ],
+                        "minimum": 0,
+                        "maximum": 65535,
+                        "format": "uc-portrange"
+                    }
+                },
+                "destination-address": {
+                    "type": "string",
+                    "format": "ipv6",
+                    "example": "::1000"
+                },
+                "destination-ports": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": [
+                            "integer",
+                            "string"
+                        ],
+                        "minimum": 0,
+                        "maximum": 65535,
+                        "format": "uc-portrange"
+                    }
+                }
+            },
+            "required": [
+                "destination-address"
+            ]
         },
         "interface.ipv6": {
             "type": "object",
@@ -765,6 +902,18 @@
                 },
                 "dhcpv6": {
                     "$ref": "#/$defs/interface.ipv6.dhcpv6"
+                },
+                "port-forward": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/interface.ipv6.port-forward"
+                    }
+                },
+                "traffic-allow": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/interface.ipv6.traffic-allow"
+                    }
                 }
             }
         },

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -850,7 +850,7 @@
                 },
                 "gateway-fqdn": {
                     "type": "string",
-                    "format": "fqdn",
+                    "format": "uc-fqdn",
                     "default": "ucentral.splash"
                 },
                 "max-clients": {
@@ -2184,7 +2184,7 @@
                                     "properties": {
                                         "fqdn": {
                                             "type": "string",
-                                            "format": "fqdn"
+                                            "format": "uc-fqdn"
                                         },
                                         "suffix-matching": {
                                             "type": "boolean",


### PR DESCRIPTION
This PR introduces two new interface.ipv4/ipv6 properties `port-forward` and `traffic-allow` which allow configuring port forwards (DNAT) and forwarding accept rules respectively.

It also bundles a number of somewhat related fixes found while implementing the firewall settings. 