### PR TITLE
renderer: quote wireless encryption key

### DIFF
--- a/renderer/templates/interface/ssid.uc
+++ b/renderer/templates/interface/ssid.uc
@@ -271,7 +271,7 @@ set wireless.{{ section }}.fils_discovery_max_interval={{ ssid.fils_discovery_in
 set wireless.{{ section }}.ieee80211w={{ match_ieee80211w(phy) }}
 set wireless.{{ section }}.sae_pwe={{ match_sae_pwe(phy) }}
 set wireless.{{ section }}.encryption={{ crypto.proto }}
-set wireless.{{ section }}.key={{ crypto.key }}
+set wireless.{{ section }}.key={{ s(crypto.key) }}
 
 {%   if (crypto.eap_local): %}
 set wireless.{{ section }}.eap_server=1


### PR DESCRIPTION
PSK can contain spaces, so we need to quote them. Not doing so will
truncate the PSK, and in case the first word is less than 8 characters,
the following error will be thrown:

  netifd: radio2 (22275): Interface 0 setup failed: INVALID_WPA_PSK

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>
